### PR TITLE
项目start的默认启动端口改为3001，避开和node端口冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "whatwg-fetch": "2.0.3"
   },
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "PORT=3001 react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom"
   },


### PR DESCRIPTION
项目start的默认启动端口改为3001